### PR TITLE
Improve contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             --border-color-bright: rgba(255, 255, 255, 0.3);
             --glow-color: rgba(88, 166, 255, 0.5);
             --text-color: #E6EDF3;
-            --text-muted-color: #8B949E;
+            --text-muted-color: #C9D1D9;
             --accent-blue: #58A6FF;
             --accent-green: #3FB950;
             --accent-purple: #BC8CFF;
@@ -251,10 +251,10 @@
     </div>
 
     <header class="relative z-10 text-center py-16 px-4">
-        <h1 class="text-5xl md:text-6xl font-extrabold mb-4 text-transparent bg-clip-text bg-gradient-to-r from-gray-200 to-gray-500">
+        <h1 class="text-5xl md:text-6xl font-extrabold mb-4 text-transparent bg-clip-text bg-gradient-to-r from-gray-200 to-gray-400">
             AI Concepts Explorer
         </h1>
-        <p class="text-lg md:text-xl text-gray-400 max-w-3xl mx-auto">
+        <p class="text-lg md:text-xl text-gray-300 max-w-3xl mx-auto">
             An interactive journey through the fundamental building blocks of modern AI.
         </p>
         
@@ -285,7 +285,7 @@
     <div id="modal" class="fixed inset-0 z-50 hidden items-center justify-center p-4">
         <div class="modal-backdrop absolute inset-0"></div>
         <div class="modal-content-area relative w-full max-w-2xl max-h-[90vh] overflow-y-auto p-8 rounded-2xl smooth-appear">
-            <button id="close-modal" class="absolute top-4 right-4 text-gray-400 hover:text-white transition-colors">
+            <button id="close-modal" class="absolute top-4 right-4 text-gray-300 hover:text-white transition-colors">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                 </svg>
@@ -459,7 +459,7 @@
             container.innerHTML = `
                 <input type="text" placeholder="Type something..." class="w-full bg-transparent border-b border-gray-600 focus:border-blue-400 outline-none pb-1 mb-3 text-sm">
                 <div class="token-output flex flex-wrap gap-1.5 min-h-[40px]"></div>
-                <div class="text-xs text-gray-400 mt-auto pt-2">Tokens: <span class="token-count">0</span></div>`;
+                <div class="text-xs text-gray-300 mt-auto pt-2">Tokens: <span class="token-count">0</span></div>`;
             
             const input = container.querySelector('input');
             const output = container.querySelector('.token-output');
@@ -548,7 +548,7 @@
             container.innerHTML = `
                 <div class="text-center mb-2"><div class="temp-emoji text-4xl transition-all duration-300">😐</div></div>
                 <input type="range" class="temperature" min="0" max="2" step="0.1" value="0.7">
-                <div class="text-xs text-center mt-2 text-gray-400">Temp: <span class="temp-val">0.7</span></div>`;
+                <div class="text-xs text-center mt-2 text-gray-300">Temp: <span class="temp-val">0.7</span></div>`;
 
             const slider = container.querySelector('.temperature');
             const val = container.querySelector('.temp-val');
@@ -753,7 +753,7 @@
             container.innerHTML = `<div class="grid grid-cols-8 gap-1.5"></div>
                 <div class="text-center mt-3">
                     <input type="range" class="bs-slider" min="1" max="32" value="8" class="w-full">
-                    <p class="text-xs text-gray-400 mt-2">Batch Size: <span class="bs-val">8</span></p>
+                    <p class="text-xs text-gray-300 mt-2">Batch Size: <span class="bs-val">8</span></p>
                 </div>`;
             const grid = container.querySelector('.grid');
             const slider = container.querySelector('.bs-slider');
@@ -777,7 +777,7 @@
 
         function initGradientDescent(container) {
              container.innerHTML = `<canvas class="w-full h-full rounded-lg cursor-pointer"></canvas>
-             <p class="text-xs text-center text-gray-400 mt-2">Click to drop the ball</p>`;
+             <p class="text-xs text-center text-gray-300 mt-2">Click to drop the ball</p>`;
             const canvas = container.querySelector('canvas');
             const ctx = canvas.getContext('2d');
             let ball = {x: 30, y: 10, vx: 0, vy: 0};
@@ -964,7 +964,7 @@
         
         function initContextWindow(container) {
             container.innerHTML = `<div class="relative h-24 bg-gray-900 rounded p-2 overflow-hidden">
-                <p class="text-xs text-gray-500">The quick brown fox jumps over the lazy dog. A large context window allows the model to remember earlier parts of the text, like the mention of the 'quick brown fox', when generating new content later on, improving coherence.</p>
+                <p class="text-xs text-gray-300">The quick brown fox jumps over the lazy dog. A large context window allows the model to remember earlier parts of the text, like the mention of the 'quick brown fox', when generating new content later on, improving coherence.</p>
                 <div class="context-window absolute top-0 left-0 h-full bg-pink-500/20 border-x-2 border-pink-400"></div>
             </div>
             <input type="range" class="cw-slider" min="20" max="100" value="40" class="w-full mt-3">`;
@@ -1014,7 +1014,7 @@
         }
         
         function initFineTuning(container) {
-            container.innerHTML = `<div class="flex justify-between text-xs text-gray-400 mb-1">
+            container.innerHTML = `<div class="flex justify-between text-xs text-gray-300 mb-1">
                 <span>Base Model</span><span>Specialized</span>
             </div>
             <div class="w-full bg-gray-700 rounded-full h-2"><div class="ft-progress bg-gradient-to-r from-blue-500 to-pink-500 h-2 rounded-full w-[10%] transition-all duration-500"></div></div>
@@ -1029,11 +1029,11 @@
         function initPromptEngineering(container) {
             container.innerHTML = `<div class="space-y-3">
                 <div>
-                    <label class="text-xs text-gray-400">Basic Prompt:</label>
+                    <label class="text-xs text-gray-300">Basic Prompt:</label>
                     <p class="text-xs bg-gray-900 p-2 rounded">Tell me about dogs.</p>
                 </div>
                 <div>
-                    <label class="text-xs text-gray-400">Engineered Prompt:</label>
+                    <label class="text-xs text-gray-300">Engineered Prompt:</label>
                     <p class="text-xs bg-gray-900 p-2 rounded">Act as a veterinarian. Write a summary of common health issues in golden retrievers for a new dog owner. Use simple language.</p>
                 </div>
             </div>`;
@@ -1058,7 +1058,7 @@
         function initQuantization(container) {
             container.innerHTML = `<div class="text-center">
                 <p class="text-2xl font-bold text-pink-400 model-size">12.4 GB</p>
-                <p class="text-xs text-gray-400 precision">FP32 (Full Precision)</p>
+                <p class="text-xs text-gray-300 precision">FP32 (Full Precision)</p>
             </div>
             <button class="secondary-btn mt-3">Quantize to INT8</button>`;
             const size = container.querySelector('.model-size');
@@ -1089,7 +1089,7 @@
         function initBeamSearch(container) {
             container.innerHTML = `<canvas class="w-full h-24"></canvas>
             <div class="text-center mt-2">
-                <label class="text-xs text-gray-400">Beam Width: <span class="beam-val">2</span></label>
+                <label class="text-xs text-gray-300">Beam Width: <span class="beam-val">2</span></label>
                 <input type="range" class="beam-slider" min="1" max="5" value="2" class="w-full mt-1">
             </div>`;
             const canvas = container.querySelector('canvas');
@@ -1140,6 +1140,11 @@
         }, 100);
 
         window.addEventListener('resize', debouncedResize);
+
+        // Ensure canvases render correctly once all styles are loaded
+        window.addEventListener('load', () => {
+            canvasDrawFunctions.forEach(func => func());
+        });
 
         categoryButtons.forEach(btn => {
             btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- lighten the gradient heading
- use brighter gray text for various elements
- lighten the muted text variable
- redraw interactive canvases once the page fully loads

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685395f7c4848321a593e978cde8bf7d